### PR TITLE
Add README for Liaison Slackbot

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,39 @@
+# Liaison
+
+Communicating issues to E-Board since 2025
+
+## Overview
+Liason is a very important Slackbot that can be used to give anonymous feedback to E-Board members, and have a productive anonymous conversation between members and E-Board
+Liason is a replacement of [E-Board Evals](https://github.com/ComputerScienceHouse/eboard-evals)
+## How to Use
+
+Find the Liason bot in Slack, most easily by typing "Liason" into the search bar at the top. 
+
+Send a direct message (DM) to Liason if you want the help message.
+
+The command to start a thread is <code>/start @''usergroup'' ''topic''.</code>
+* ''usergroup'' is the people you want to ping when the Liason is sent. You can do @eboard, a specific directorship (@socials), or a specific person (@csmouse), depending on who you want to talk to. 
+* ''topic'' is the topic that you want to talk to E-Board about. 
+
+Liason will send you a new DM: <code>Conversation :thread: here @''your display name'' about @''user group'' ''topic''</code>
+
+This will send a message to the private channel <code>eboard-liasons</code>. It will ping the group that you typed, and show the topic that you put.  
+
+You should then type your concerns in a thread of the message that Liason sends. If the message is successfully sent to E-Board, Liason will react :circle-game: to the message. 
+
+When you send messages, they will be relayed to E-Board in an anonymous manner, with all messages showing they are from "Concerned Member".
+
+When E-Board sends messages, they will be relayed to the thread in your DMs, and all responses will come with the generic username of <code>EBoard</code>.
+
+For detailed images and 
+
+## Contributing
+
+1. [Fork](https://help.github.com/en/articles/fork-a-repo) this repository
+    - Create a new [git branch](https://git-scm.com/book/en/v2/Git-Branching-Branches-in-a-Nutshell) if your change is more than a small tweak (`git checkout -b BRANCH-NAME-HERE`)
+3. Make your changes locally, commit, and push to your fork
+4. Create a [Pull Request](https://help.github.com/en/articles/about-pull-requests) on this repo for our Webmasters to review
+
+## Questions/Concerns
+
+Please file an [Issue](https://github.com/ComputerScienceHouse/pubsite/issues/new) on this repository or contact [webmaster@csh.rit.edu](mailto:webmaster@csh.rit.edu) with inquiries about the site.


### PR DESCRIPTION
Added README file for the Liaison Slackbot, detailing its purpose, usage instructions, contribution guidelines, and contact information.

## What

Adds Reads

## Why

Needs Readme

## Test Plan
Looked at preview

## Env Vars
no

## Documentation

This literally is documentation

## Checklist

- [x] Tested all changes locally
